### PR TITLE
Fix cascading trigger

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,5 @@
 libtree is written and maintained by Fabian Kochem.
+
+Contributors:
+
+James Hutchby

--- a/libtree/sql/triggers.sql
+++ b/libtree/sql/triggers.sql
@@ -89,6 +89,7 @@ CREATE CONSTRAINT TRIGGER update_ancestors_after_delete
 AFTER DELETE
 ON nodes
 FOR EACH ROW
+WHEN (pg_trigger_depth() = 0)
 EXECUTE PROCEDURE update_ancestors_after_delete();
 
 


### PR DESCRIPTION
When a node is deleted, update_ancestors_after_delete trigger runs,
causing more nodes to be deleted.
Previously this would cause a cascade of triggers.
This change prevents this (unnecessary) cascade.